### PR TITLE
Send Test Unit Ready command to ATAPI drives *twice* during initialis…

### DIFF
--- a/AROS/rom/devs/ata/ata.conf
+++ b/AROS/rom/devs/ata/ata.conf
@@ -1,6 +1,6 @@
 ##begin config
 basename        ata
-version		43.0
+version		43.2
 libbasetype     struct ataBase
 residentpri     4
 beginio_func    BeginIO

--- a/AROS/rom/devs/ata/lowlevel.c
+++ b/AROS/rom/devs/ata/lowlevel.c
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2004-2014, The AROS Development Team. All rights reserved.
+    Copyright © 2004-2018, The AROS Development Team. All rights reserved.
     $Id$
 
     Desc:
@@ -1970,6 +1970,7 @@ int atapi_TestUnitOK(struct ata_Unit *unit)
     struct SCSICmd sc = {
        0
     };
+    UWORD i;
 
     D(bug("[ATA%02ld] atapi_TestUnitOK()\n", unit->au_UnitNum));
 
@@ -1980,7 +1981,11 @@ int atapi_TestUnitOK(struct ata_Unit *unit)
     sc.scsi_Flags = SCSIF_AUTOSENSE;
 
     DATAPI(bug("[ATA%02ld] atapi_TestUnitOK: Testing Unit Ready sense...\n", unit->au_UnitNum));
-    unit->au_DirectSCSI(unit, &sc);
+
+    /* Send command twice, and take the second result, as some drives give
+     * invalid (or at least not so useful) sense data straight after reset */
+    for (i = 0; i < 2; i++)
+        unit->au_DirectSCSI(unit, &sc);
     unit->au_SenseKey = sense[2];
 
     /*


### PR DESCRIPTION
…ation,

and take the second result, as some drives give invalid (or at least not so
useful) sense data straight after reset.


git-svn-id: https://svn.aros.org/svn/aros/trunk@55494 fb15a70f-31f2-0310-bbcc-cdcc74a49acc