### PR TITLE
Avoid direct (A)RGB pen colours (currently unimplemented) being

### DIFF
--- a/AROS/workbench/libs/muimaster/textengine.c
+++ b/AROS/workbench/libs/muimaster/textengine.c
@@ -423,7 +423,8 @@ static CONST_STRPTR parse_escape_code(ZTextLine * ztl,
     case 'P':                  /* pen number */
         {
             LONG pen;
-            char *t;
+            STRPTR t;
+            UWORD len;
 
             if (*s != '[')
                 break;
@@ -434,12 +435,16 @@ static CONST_STRPTR parse_escape_code(ZTextLine * ztl,
             t = strchr(s, ']');
             if (t == NULL)
                 break;
-            *t = 0;
-            if (StrToLong(s, &pen) == -1)
-                pen = 0;
-            D(bug("pen = %ld\n", pen));
-            zc->pen = pen;
-            *t = ']';
+            len = t - s;
+            if (len < 6)
+            {
+                *t = 0;
+                if (StrToLong(s, &pen) == -1)
+                    pen = 0;
+                D(bug("pen = %ld\n", pen));
+                zc->pen = pen;
+                *t = ']';
+            }
             zc->text = s - 1;
             zune_text_chunk_new(zc);
             zc->text_start = t + 1;


### PR DESCRIPTION
misinterpreted as ordinary pen numbers.


git-svn-id: https://svn.aros.org/svn/aros/trunk@55510 fb15a70f-31f2-0310-bbcc-cdcc74a49acc