### PR TITLE
Pull from upstream

### DIFF
--- a/AROS/Makefile.in
+++ b/AROS/Makefile.in
@@ -1,4 +1,4 @@
-# Copyright © 2000-2016, The AROS Development Team. All rights reserved.
+# Copyright © 2000-2019, The AROS Development Team. All rights reserved.
 # $Id$
 #
 # Main makefile for AROS
@@ -107,7 +107,7 @@ makedirs:
 	else true ; fi
 
 # Create the tools that are used to build AROS.
-tools : makedirs mmake $(GENMF) $(ARCHTOOL) $(ELF2HUNK) \
+tools : makedirs mmake $(GENMFSCRIPT) $(ARCHTOOL) $(ELF2HUNK) \
 	$(FLEXCAT) $(CREATEDTDESC) \
 	$(ILBMTOC) $(ILBMTOICON) $(INFOINFO) \
 	$(COLLECT-AROS) $(AFSLIB) $(COPYTOAFS) \
@@ -132,9 +132,9 @@ $(TOP)/config/features.status: $(SRCDIR)/config/features $(CROSSTOOLS_BUILDFLAG)
 features: crosstools $(TOP)/config/features.status
 	@$(NOP)
 
-$(GENMF): $(SRCDIR)/tools/genmf/genmf.py
-	@$(ECHO) Copying genmf...
-	@./config.status $(subst $(TOP)/,,$(GENMF)) genmf_executable
+$(GENMFSCRIPT): $(SRCDIR)/tools/genmf/genmf.py
+	@$(ECHO) Generating $(subst $(TOP)/,,$(GENMFSCRIPT))...
+	@./config.status $(subst $(TOP)/,,$(GENMFSCRIPT)) genmf_executable
 
 $(ELF2HUNK): $(SRCDIR)/tools/elf2hunk/elf2hunk.c
 	@$(ECHO) Building elf2hunk...
@@ -209,7 +209,7 @@ $(TOP)/tools/MetaMake/Makefile: $(SRCDIR)/tools/MetaMake/configure $(SRCDIR)/too
 	fi;
 	@cd $(TOP)/tools/MetaMake ; CC="$(HOST_CC)" CFLAGS="$(HOST_CFLAGS) -D_FILE_OFFSET_BITS=64" LDFLAGS="$(HOST_LDFLAGS)" $(SRCDIR)/tools/MetaMake/configure --prefix=$(TOOLDIR) --bindir=$(TOOLDIR) --with-objfiledir=$(HOSTGENDIR)/tools/MetaMake
 
-$(MMAKE): $(TOP)/tools/MetaMake/Makefile $(wildcard $(SRCDIR)/tools/MetaMake/*.[ch]) $(GENMF)
+$(MMAKE): $(TOP)/tools/MetaMake/Makefile $(wildcard $(SRCDIR)/tools/MetaMake/*.[ch]) $(GENMFSCRIPT)
 	@$(MAKE) $(MKARGS) AUTOHEADER=@aros_host_autoheader@ -C $(TOP)/tools/MetaMake
 	@$(MAKE) $(MKARGS) -C $(TOP)/tools/MetaMake install
 

--- a/AROS/config/make.cfg.in
+++ b/AROS/config/make.cfg.in
@@ -1,4 +1,4 @@
-# Copyright © 1995-2018, The AROS Development Team. All rights reserved.
+# Copyright © 1995-2019, The AROS Development Team. All rights reserved.
 # $Id$
 #
 # Static makefile rule file for AROS.
@@ -18,8 +18,10 @@ AROS_TARGET_PLATFORM := $(AROS_TARGET_ARCH)-$(AROS_TARGET_CPU)
 endif
 
 # All files corresponding to a specific host go here.
-HOSTDIR     := $(TOP)/bin/$(AROS_HOST_ARCH)-$(AROS_HOST_CPU)
-TOOLDIR     := $(HOSTDIR)/tools
+DIR_HOST    := bin/$(AROS_HOST_ARCH)-$(AROS_HOST_CPU)
+HOSTDIR     := $(TOP)/$(DIR_HOST)
+DIR_TOOLS   := tools
+TOOLDIR     := $(HOSTDIR)/$(DIR_TOOLS)
 
 HOSTGENDIR  := $(HOSTDIR)/gen/host
 
@@ -58,9 +60,9 @@ AROSDIR	             := $(TARGETDIR)/AROS
 # Relative paths for standard directories
 AROS_DIR_BOOT        := boot
 ifeq ($(AROS_TARGET_ARCH),pc)
-AROS_DIR_ARCH        := boot/$(AROS_TARGET_ARCH)
+AROS_DIR_ARCH        := $(AROS_DIR_BOOT)/$(AROS_TARGET_ARCH)
 else
-AROS_DIR_ARCH        := boot/$(AROS_TARGET_ARCH)$(AROS_TARGET_SUFFIX)
+AROS_DIR_ARCH        := $(AROS_DIR_BOOT)/$(AROS_TARGET_ARCH)$(AROS_TARGET_SUFFIX)
 endif
 AROS_DIR_C           := C
 AROS_DIR_CLASSES     := Classes
@@ -128,7 +130,7 @@ SCRIPTDIR            := $(GENDIR)/scripts
 
 MKDEPEND             := $(SRCDIR)/scripts/mkdep
 FETCH                := $(SRCDIR)/scripts/fetch.sh
-CPYDIRREC            := @PYTHON@ $(SRCDIR)/scripts/cpy-dir-rec.py
+CPYDIRREC            := $(PYTHON) $(SRCDIR)/scripts/cpy-dir-rec.py
 
 # The paths to the generated tools
 TOOLDIR		:= $(HOSTDIR)/tools
@@ -136,7 +138,8 @@ TOOLLIB		:= $(TOOLDIR)/libtool.a
 MMAKE		:= $(TOOLDIR)/mmake$(HOST_EXE_SUFFIX)
 ARCHTOOL	:= $(TOOLDIR)/archtool$(HOST_EXE_SUFFIX)
 ELF2HUNK	:= $(TOOLDIR)/elf2hunk$(HOST_EXE_SUFFIX)
-GENMF		:= $(TOOLDIR)/genmf.py
+GENMFSCRIPT	:= $(TOOLDIR)/genmf.py
+GENMF		:= $(PYTHON) $(GENMFSCRIPT)
 FLEXCAT		:= $(TOOLDIR)/flexcat$(HOST_EXE_SUFFIX)
 FD2INLINE       := $(TOOLDIR)/fd2inline$(HOST_EXE_SUFFIX)
 FD2PRAGMA       := $(TOOLDIR)/fd2pragma$(HOST_EXE_SUFFIX)

--- a/AROS/config/target.cfg.in
+++ b/AROS/config/target.cfg.in
@@ -1,4 +1,4 @@
-#   Copyright © 1995-2018, The AROS Development Team. All rights reserved.
+#   Copyright © 1995-2019, The AROS Development Team. All rights reserved.
 #   $Id$
 #
 #   Desc: target.cfg - an autoconf output file for make variables.
@@ -107,7 +107,8 @@ GCC_DEFAULT_MODE        := @gcc_default_mode@
 # --------------------------------------------------------------------------
 HOSTDIR         := $(TOP)/bin/$(AROS_HOST_ARCH)-$(AROS_HOST_CPU)
 TOOLDIR         := $(HOSTDIR)/tools
-GENMF           := $(TOOLDIR)/genmf.py
+GENMFSCRIPT	:= $(TOOLDIR)/genmf.py
+GENMF		:= $(PYTHON) $(GENMFSCRIPT)
 ARCH            := $(AROS_TARGET_ARCH)
 CPU             := $(AROS_TARGET_CPU)
 CPU_MODE        := $(AROS_TARGET_CPU_MODE)


### PR DESCRIPTION
Always use  to access the interpreter. Call Python directly when running the genmf.py script so that it works on platforms that do not support shebangs. (NicJA)

git-svn-id: https://svn.aros.org/svn/aros/trunk@55670 fb15a70f-31f2-0310-bbcc-cdcc74a49acc