### PR TITLE
when kernel_cc == target_cc use the target iquote configuration.

### DIFF
--- a/AROS/config/target.cfg.in
+++ b/AROS/config/target.cfg.in
@@ -80,8 +80,8 @@ FUNCINSTR_FLAGS               = $(CFLAGS_INSTR_FUNCTIONS)
 FUNCINSTR_LIBS                = instrfunc
 
 NOSTDINC_CFLAGS               := @aros_target_nostdinc_cflags@
-KERNEL_IQUOTE                 := @kernel_cflags_iquote@
-KERNEL_IQUOTE_END             := @kernel_cflags_iquote_end@
+KERNEL_IQUOTE                 = @kernel_cflags_iquote@
+KERNEL_IQUOTE_END             = @kernel_cflags_iquote_end@
 NOSTARTUP_LDFLAGS             := @aros_target_nostartup_ldflags@
 NIX_LDFLAGS                   := @aros_target_nix_ldflags@
 DETACH_LDFLAGS                := @aros_target_detach_ldflags@

--- a/AROS/configure
+++ b/AROS/configure
@@ -14105,6 +14105,9 @@ $as_echo "$use_hash_style" >&6; }
     if test "x-$use_hash_style" = "x-yes" ; then
         aros_kernel_cflags="$aros_kernel_cflags -Wl,--hash-style=sysv"
     fi
+else
+    kernel_cflags_iquote="$""(CFLAGS_IQUOTE)"
+    kernel_cflags_iquote_end="$""(CFLAGS_IQUOTE_END)"
 fi
 CC="$save_cc"
 CFLAGS="$save_cflags"

--- a/AROS/configure.in
+++ b/AROS/configure.in
@@ -2638,6 +2638,9 @@ if test "x$test_kernel_cc" != "xno"; then
     if test "x-$use_hash_style" = "x-yes" ; then
         aros_kernel_cflags="$aros_kernel_cflags -Wl,--hash-style=sysv"
     fi
+else
+    kernel_cflags_iquote="$""(CFLAGS_IQUOTE)"
+    kernel_cflags_iquote_end="$""(CFLAGS_IQUOTE_END)"
 fi
 CC="$save_cc"
 CFLAGS="$save_cflags"


### PR DESCRIPTION
git-svn-id: https://svn.aros.org/svn/aros/trunk@55901 fb15a70f-31f2-0310-bbcc-cdcc74a49acc