### PR TITLE
Merge upstream

### DIFF
--- a/AROS/workbench/libs/glu/glu-9.0.0-aros.diff
+++ b/AROS/workbench/libs/glu/glu-9.0.0-aros.diff
@@ -1,6 +1,6 @@
 diff -ruN glu-9.0.0/src/libnurbs/interface/insurfeval.cc glu-9.0.0.aros/src/libnurbs/interface/insurfeval.cc
---- glu-9.0.0/src/libnurbs/interface/insurfeval.cc	2012-09-14 20:48:54.000000000 -0400
-+++ glu-9.0.0.aros/src/libnurbs/interface/insurfeval.cc	2015-04-19 17:13:37.212360145 -0400
+--- glu-9.0.0/src/libnurbs/interface/insurfeval.cc	2012-09-15 01:48:54.000000000 +0100
++++ glu-9.0.0.aros/src/libnurbs/interface/insurfeval.cc	2019-04-03 20:07:20.650123200 +0100
 @@ -1344,6 +1344,8 @@
    free(lowerXYZ);
    free(upperNormal);
@@ -20,8 +20,8 @@ diff -ruN glu-9.0.0/src/libnurbs/interface/insurfeval.cc glu-9.0.0.aros/src/libn
  
  /*-----------------------begin evalMachine-------------------*/
 diff -ruN glu-9.0.0/src/libnurbs/nurbtess/sampleCompTop.cc glu-9.0.0.aros/src/libnurbs/nurbtess/sampleCompTop.cc
---- glu-9.0.0/src/libnurbs/nurbtess/sampleCompTop.cc	2012-09-14 20:48:54.000000000 -0400
-+++ glu-9.0.0.aros/src/libnurbs/nurbtess/sampleCompTop.cc	2015-04-19 17:14:42.942805024 -0400
+--- glu-9.0.0/src/libnurbs/nurbtess/sampleCompTop.cc	2012-09-15 01:48:54.000000000 +0100
++++ glu-9.0.0.aros/src/libnurbs/nurbtess/sampleCompTop.cc	2019-04-03 20:07:20.655097500 +0100
 @@ -511,26 +511,6 @@
      }
    else if(up_rightCornerWhere != 2)
@@ -49,3 +49,26 @@ diff -ruN glu-9.0.0/src/libnurbs/nurbtess/sampleCompTop.cc glu-9.0.0.aros/src/li
        sampleCompTopSimple(topVertex,
  			  leftChain,
  			  leftStartIndex,
+diff -ruN glu-9.0.0/src/libtess/priorityq.c glu-9.0.0.aros/src/libtess/priorityq.c
+--- glu-9.0.0/src/libtess/priorityq.c	2012-09-15 01:48:54.000000000 +0100
++++ glu-9.0.0.aros/src/libtess/priorityq.c	2019-04-10 03:14:26.089025000 +0100
+@@ -65,6 +65,7 @@
+      return NULL;
+   }
+ 
++  pq->order = NULL;
+   pq->size = 0;
+   pq->max = INIT_SIZE;
+   pq->initialized = FALSE;
+diff -ruN glu-9.0.0/src/libutil/mipmap.c glu-9.0.0.aros/src/libutil/mipmap.c
+--- glu-9.0.0/src/libutil/mipmap.c	2012-09-15 01:48:54.000000000 +0100
++++ glu-9.0.0.aros/src/libutil/mipmap.c	2019-04-10 03:13:14.787011600 +0100
+@@ -4509,6 +4509,8 @@
+ 	     glPixelStorei(GL_UNPACK_SKIP_PIXELS, psm.unpack_skip_pixels);
+ 	     glPixelStorei(GL_UNPACK_ROW_LENGTH, psm.unpack_row_length);
+ 	     glPixelStorei(GL_UNPACK_SWAP_BYTES, psm.unpack_swap_bytes);
++	     free(srcImage);
++	     free(dstImage);
+ 	     return GLU_OUT_OF_MEMORY;
+ 	  }
+ 


### PR DESCRIPTION
apply 2 fixes from the glu repository - one to prevent a memleak when malloc fails in mipmap.c and the other to prevent a null access when pqNewPriorityQ tries to free

memory using pq->order as pointer.

git-svn-id: https://svn.aros.org/svn/aros/trunk@56182 fb15a70f-31f2-0310-bbcc-cdcc74a49acc