### PR TITLE
fix typo.

### DIFF
--- a/AROS/config/make.tmpl
+++ b/AROS/config/make.tmpl
@@ -3680,7 +3680,7 @@ endif
 
 #MM
 %(mmake) :
-	$(Q)$(ECHO) "Fetching   %(archive) ..." \
+	$(Q)$(ECHO) "Fetching   %(archive) ..."
 	$(Q)$(FETCH) -ao "%(archive_origins)" -a %(archive) -s "%(suffixes)" -l $(%(mmake)-location) \
 	-d %(destination) -po "%(patches_origins)" -p "%(patches_specs)"
 	$(Q)$(IF) ! $(TEST) -f $(%(mmake)-fetchedflag) ; then \


### PR DESCRIPTION
git-svn-id: https://svn.aros.org/svn/aros/trunk@56220 fb15a70f-31f2-0310-bbcc-cdcc74a49acc